### PR TITLE
add start, stop and restart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ Recommended servers-on-demand services: [Digital Ocean Docker Droplet](https://w
 
 1. Access your server via shell (e.g. SSH)
 3. `docker pull staltz/easy-ssb-pub`
-4. `docker run -e "PUB_URL=publicurltoyourserv.er" -e "PORT=80" -p 80:80 -p 8008:8008 -i -t staltz/easy-ssb-pub`
+4. `docker run -e "PUB_URL=publicurltoyourserv.er" -e "PORT=80" -p 80:80 -p 8008:8008 -i -t staltz/easy-ssb-pub --name ssb-pub`
+
+After the container has been created, stop/start/restart the server using:
+
+* `docker stop ssb-pub`
+* `docker start ssb-pub`
+* `docker restart ssb-pub`
+
+_`docker run` creates a new container (and server key) each time. This prevents existing contacts from successfully completing the handshake._
 
 ### Deploy without Docker
 


### PR DESCRIPTION
I thought Docker might be new to some users so this would be helpful. Otherwise, they will use `docker run ...` each time they have to restart the server not realizing they are creating new containers each time and not understanding the handshake errors when existing nodes try to connect. It's also nice for containers to have meaningful names 😉 