### PR TITLE
Simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,7 @@
-FROM buildpack-deps:xenial
+FROM node:6.10
 
-RUN groupadd -r node && useradd -r -g node node
-
-RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get upgrade -y
-
-RUN apt-get install -y libleveldb-dev
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.9.1
-
-RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
-
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-ENV NVM_DIR $HOME/.nvm
-RUN . $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
-
-RUN git clone https://github.com/jedisct1/libsodium.git
-RUN cd /libsodium && git checkout && ./autogen.sh
-RUN cd /libsodium && ./configure && make && make check && make install
-
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-
-COPY package.json /usr/src/app/
-RUN . $HOME/.nvm/nvm.sh && npm install
 COPY . /usr/src/app
+RUN npm install
 
-EXPOSE 80
-EXPOSE 8008
-EXPOSE 8007
-
-CMD . $HOME/.nvm/nvm.sh && npm start
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ However, to join the wider SSB network, you must get a dedicated invitation from
 #### If you want to visit an Easy SSB Pub, here are a few known links (potentially ephemeral or broken):
 
 - [http://82.196.3.140/](http://82.196.3.140/)
+- [http://pub.locksmithdon.net/](http://pub.locksmithdon.net/)
 - [(add yours here)](https://github.com/staltz/easy-ssb-pub/edit/master/README.md)
 
 ## How to deploy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,11 +4,13 @@ services:
     build: .
     environment:
       PUB_URL: "${PUB_URL}"
+      SSB_PATH: /shared/.ssb
     ports:
       - "80:80"
       - "8008:8008"
       - "8007:8007"
     container_name: easy-ssb-pub
-    mem_limit: 450M
-    memswap_limit: 1G
+    mem_limit: 768M
+    volumes:
+      - $HOME/shared:/shared
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "scripts": {
     "compile": "tsc",
-    "start": "tsc && node dist/index --host $PUB_URL"
+    "start": "tsc && node dist/index --host $PUB_URL --path $SSB_PATH"
   },
   "engines": {
     "node": "6.9.1"


### PR DESCRIPTION
There is quite a bit in the `Dockerfile` that isn't needed if you use an official Node image. And the necessary LevelDB dependencies are installed with `npm install`.

I increased the RAM ceiling to use more of a common 1GB limit and removed the swap limitation since that's just disk that may or may not be available.

I'm also a big fan of docker-compose, but in order for the `.ssb` folder to be placed in the host's `/shared` folder, we need to pass the `--path` option to Scuttlebot.