### PR TITLE
Generate the manifest.json file for the scuttlebutt server.

### DIFF
--- a/src/scuttlebot.ts
+++ b/src/scuttlebot.ts
@@ -4,6 +4,7 @@ import ssbKeys = require('ssb-keys');
 import confInject = require('ssb-config/inject');
 import path = require('path');
 import {SBOT_PORT, debug} from './config';
+import fs = require('fs');
 
 export interface FullSSBConfig {
   party: boolean;
@@ -169,6 +170,9 @@ export function createScuttlebot(): {ssbBot: FullScuttlebot, ssbConf: FullSSBCon
       .use(require('scuttlebot/plugins/logging'))
       .use(require('scuttlebot/plugins/private'));
   const ssbBot: FullScuttlebot = createSbot(ssbConf);
+
+  const manifestFile = path.join(ssbConf.path, 'manifest.json');
+  fs.writeFileSync(manifestFile, JSON.stringify(ssbBot.getManifest(), null, 2));
 
   ssbBot.address((err: any, addr: string) => {
     if (err) {


### PR DESCRIPTION
Got some pointers from @ahdinosaur about the `manifest.json` file in this thread [%akCXrfqgWBCEn995qEvTQ8oVJB8JRTttucp3HDGVKrI=.sha256](http://viewer.scuttlebot.io/%25akCXrfqgWBCEn995qEvTQ8oVJB8JRTttucp3HDGVKrI=.sha256) and decided to add it. Works on my server, figured it could be useful to everyone running easy-ssb-pub.

Based on the code [already in sbot](https://github.com/ssbc/scuttlebot/blob/master/bin.js#L58-L59).