### PR TITLE
Pin typescript version to avoid breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "stream-to-pull-stream": "^1.7.2",
     "streamview-links": "^2.1.1",
     "superagent": "^3.5.0",
-    "typescript": "^2.3.2"
+    "typescript": "2.3.2"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",


### PR DESCRIPTION
## Issues

Closes #18

TypeScript seems to ship breaking changes upstream as patch version bumps. Currently, if you `git clone` this repo and attempt to run the pub, you get:

```
> easy-ssb-pub@4.0.0 start /usr/src/app
> tsc && node dist/index --host $HOST --no-discovery

src/discovery.ts(113,3): error TS2322: Type 'Observable<{}>' is not assignable to type 'Observable<Response>'.
    Type '{}' is not assignable to type 'Response'.
        Property 'text' is missing in type '{}'.
```
# Changes

This PR pins to a specific, known working, version of TypeScript. Opting into future releases requires an explicit upgrade.
