### PR TITLE
Fix nvm installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ ENV NODE_VERSION 6.10.3
 
 RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
 
+RUN git clone https://github.com/jedisct1/libsodium.git
+RUN cd /libsodium && git checkout && ./autogen.sh
+RUN cd /libsodium && ./configure && make && make check && make install
+
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
 
 # NOTE: /root is used here because $HOME does not work and neither does ~
 ENV NVM_DIR /root/.nvm
 RUN . $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
-
-RUN git clone https://github.com/jedisct1/libsodium.git
-RUN cd /libsodium && git checkout && ./autogen.sh
-RUN cd /libsodium && ./configure && make && make check && make install
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ENV NODE_VERSION 6.10.3
 RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-ENV NVM_DIR ~/.nvm
+
+# NOTE: /root is used here because $HOME does not work and neither does ~
+ENV NVM_DIR /root/.nvm
 RUN . $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
 
 RUN git clone https://github.com/jedisct1/libsodium.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get upgrade -y
 RUN apt-get install -y libleveldb-dev
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.10.3
+ENV NODE_VERSION 8.9.4
 
 RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV NODE_VERSION 6.10.3
 RUN apt-get install curl libc6 libcurl3 zlib1g libtool autoconf
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-ENV NVM_DIR $HOME/.nvm
+ENV NVM_DIR ~/.nvm
 RUN . $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION && nvm alias default $NODE_VERSION
 
 RUN git clone https://github.com/jedisct1/libsodium.git


### PR DESCRIPTION
The only important change here is line 23,`ENV NVM_DIR /root/.nvm`. The old version, `ENV NVM_DIR $HOME/.nvm` doesn't work because Docker doesn't recognize $HOME in that context. So, it thinks `NVM_DIR` is actually `/.nvm`, which causes that directory to be created and node versions to be installed in there, which messes up the installation.

While I was testing this out I moved libsodium earlier in the Dockerfile because it's the lengthiest step and altering the node install shouldn't re-trigger a libsodium build.

I also unnecessarily bumped up the node version, because why not?

If you want I can get rid of these extraneous changes.