### PR TITLE
Automatically set profile name to $HOST on startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import {setupScuttlebot} from './scuttlebot';
 import {setupDiscoveryPeer} from './discovery';
 import {setupExpressApp} from './http';
+import {setName} from './set-name';
 
 const {ssbBot, ssbConf} = setupScuttlebot();
 setupDiscoveryPeer({bot: ssbBot, config: ssbConf});
 setupExpressApp({bot: ssbBot});
+setName({bot: ssbBot});

--- a/src/set-name.ts
+++ b/src/set-name.ts
@@ -1,0 +1,52 @@
+
+import pull = require('pull-stream');
+import {Scuttlebot} from './scuttlebot';
+
+interface Options {
+  bot:
+    Pick<Scuttlebot, 'id'> &
+    Pick<Scuttlebot, 'whoami'> &
+    Pick<Scuttlebot, 'createUserStream'> &
+    Pick<Scuttlebot, 'publish'>;
+}
+
+/**
+ * Attempt to set the profile name.
+ *
+ * If $HOST is set, and this account has never sent an 'about' message,
+ * then create an about message with the name = $HOST.
+ * Otherwise, do nothing.
+ */
+export function setName({bot} : Options) {
+
+  const aboutName: string = process.env.HOST;
+
+  if (!aboutName) {
+    console.error("The HOST env variable must be set in order to update the profile name")
+    process.exit(1)
+  }
+
+  bot.whoami((err: string, {id} : {id: string}) => {
+    pull(
+      bot.createUserStream({id}),
+      pull.filter((msg: any) => msg.value.content.type === "about"),
+      pull.collect((err: string, msgs: [any]) => {
+        if (msgs.length == 0) {
+          bot.publish({
+            type: 'about',
+            about: id,
+            name: aboutName
+          }, (err: string, info: string) => {
+            if (err) {
+              console.error("Could not update profile name!", err)
+            } else {
+              console.log("Profile name updated.")
+            }
+          })
+        } else {
+          console.log("About message already published!")
+        }
+      })
+    )
+  })
+}


### PR DESCRIPTION
I'm not sure of the target audience of easy-ssb-pub, but this script will save the user from having to manually issue an `sbot` command on the server to set the pub name, which is definitely "easy".

This PR adds a startup step which checks for any "about" messages sent by this account. If no such messages exist, and $HOST is set, create an about message which sets the name = $HOST. Otherwise, do nothing.

If we don't do something like this, we should probably at least update the README to describe how you can set the name yourself.